### PR TITLE
Changing the "Log Name" for the events being logged instead of always "Application"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.2 (5/24/2013)
+===============
+
+* [#2](https://github.com/dblock/log4jna/pull/2): Added ability to change the log name - [@marmstrong](https://github.com/marmstrong).
+
 1.1 (6/13/2012)
 ===============
 

--- a/log4jna/src-test/org/apache/log4jna/nt/Win32EventLogAppenderTest.java
+++ b/log4jna/src-test/org/apache/log4jna/nt/Win32EventLogAppenderTest.java
@@ -42,7 +42,7 @@ public class Win32EventLogAppenderTest extends TestCase {
 	private Logger _logger = null;
 	
 	public void setUp() {
-		BasicConfigurator.configure(new Win32EventLogAppender());
+		BasicConfigurator.configure(new Win32EventLogAppender(null, null, "Log4jnaTest"));
 		_logger = Logger.getLogger(Win32EventLogAppenderTest.class);		
 	}
 	
@@ -86,7 +86,7 @@ public class Win32EventLogAppenderTest extends TestCase {
 	*/
 	
 	private void expectEvent(String message, Level level, EventLogType eventLogType) {
-		EventLogIterator iter = new EventLogIterator(null, "Application", WinNT.EVENTLOG_BACKWARDS_READ);
+		EventLogIterator iter = new EventLogIterator(null, "Log4jnaTest", WinNT.EVENTLOG_BACKWARDS_READ);
 		try {
 			assertTrue(iter.hasNext());
 			EventLogRecord record = iter.next();

--- a/log4jna/src/org/apache/log4jna/nt/Win32EventLogAppender.java
+++ b/log4jna/src/org/apache/log4jna/nt/Win32EventLogAppender.java
@@ -97,7 +97,8 @@ public class Win32EventLogAppender extends AppenderSkeleton {
 		
 		this.layout = layout;
 		this._server = server;
-		this._source = source;		
+		this._source = source;
+		this._log = log;
 	}
 
 	public void close() {


### PR DESCRIPTION
We needed this in our project because the events needed to be grouped in their own log.
