### PR TITLE
Fix typo in USAGE.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -210,7 +210,7 @@ This configuration will result in the creation of Registry entries in `HKEY_LOCA
 
 The registry should look like this:
 
-![Registry Img](scr/site/resources/img/registry1.png)
+![Registry Img](src/site/resources/img/registry1.png)
 
 #### Espefiying the *Source* in the Default logger (Recommended)
 1. Open `regedit` and browse to `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\EventLog\Application\`
@@ -219,7 +219,7 @@ The registry should look like this:
 
 The registry should look like this:
 
-![Registry Img](scr/site/resources/img/registry2.png)
+![Registry Img](src/site/resources/img/registry2.png)
 
 #### Using your own application entries in Event Viwer
 Here we use the Log4J Demo values as an example.


### PR DESCRIPTION
There are a couple typos in the file that makes the images point at 404's. This patch fixes it.