### PR TITLE
fix CI (change mvn download URI and build image)

### DIFF
--- a/APPVEYOR.md
+++ b/APPVEYOR.md
@@ -40,7 +40,7 @@ install:
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\maven" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'http://www.us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip',
+          'https://dlcdn.apache.org/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip',
           'C:\maven-bin.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")

--- a/appveyor-deploy.yml
+++ b/appveyor-deploy.yml
@@ -1,5 +1,5 @@
 version: 2.0.{build}
-os: Windows Server 2012
+image: Visual Studio 2015
 
 branches:
   only:
@@ -52,7 +52,7 @@ install:
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\maven" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'http://www.us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip',
+          'https://dlcdn.apache.org/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip',
           'C:\maven-bin.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")

--- a/appveyor-mvn-release.yml
+++ b/appveyor-mvn-release.yml
@@ -1,5 +1,5 @@
 version: 2.0.{build}
-os: Visual Studio 2015
+image: Visual Studio 2015
 
 environment:
   MAVEN_HOME: C:\maven\apache-maven-3.3.9
@@ -48,7 +48,7 @@ install:
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\maven" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'http://www.us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip',
+          'https://dlcdn.apache.org/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip',
           'C:\maven-bin.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 2.0.{build}
 
-os: Windows Server 2012
+image: Visual Studio 2015
 
 branches:
   only:
@@ -25,7 +25,7 @@ install:
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\maven" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'http://www.us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip',
+          'https://dlcdn.apache.org/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip',
           'C:\maven-bin.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")


### PR DESCRIPTION
There seem to be some issues with the appveyor configuration file, which I assume is the cause of the problems we are experiencing with CI. 

* Fixed maven download link.
* Specify VS2015 w/ Windows Sever 2012 as the build environment

refs:
* https://github.com/dblock/log4jna/issues/45#issuecomment-929279143
* <https://ci.appveyor.com/project/yokra9/log4jna/builds/40954030>

Thanks!