### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "maven"
+    directory: "/log4jna-api/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "maven"
+    directory: "/log4jna-assembly/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "maven"
+    directory: "/log4jna-demo/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "maven"
+    directory: "/log4jna-doc/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "maven"
+    directory: "/log4jna-win32dll/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -3,8 +3,6 @@ name: Log4JNA Deploy
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
 
   workflow_dispatch:
 


### PR DESCRIPTION
We should fix vulnerabilities from dependencies by the 2.1 release.

I created a [Dependabot](https://docs.github.com/en/code-security/dependabot) setting for this repo. It will make PR for security fix automatically.