### PR TITLE
Fix levels mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * [#50](https://github.com/dblock/log4jna/pull/50): Upgrade to JNA 5.9.0 - [@shamus13](https://github.com/shamus13).
 * [#51](https://github.com/dblock/log4jna/pull/51): Migrate from AppVeyor to GitHub Actions. - [@yokra9](https://github.com/yokra9).
+* [#84](https://github.com/dblock/log4jna/pull/84): Fix levels mapping - [@MacTrophy](https://github.com/MacTrophy) and [@yokra9](https://github.com/yokra9).
 
 2.0 (8/8/2016)
 --------------

--- a/log4jna-api/src/main/java/org/dblock/log4jna/nt/Win32EventLogAppender.java
+++ b/log4jna-api/src/main/java/org/dblock/log4jna/nt/Win32EventLogAppender.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.spi.StandardLevel;
 
 import com.sun.jna.platform.win32.Advapi32;
 import com.sun.jna.platform.win32.Advapi32Util;
@@ -361,19 +362,19 @@ public class Win32EventLogAppender extends AbstractAppender {
 	 * @return EventLog type.
 	 */
 	private static int getEventLogType(Level level) {
-		int type = WinNT.EVENTLOG_SUCCESS;
-
-		if (level.intLevel() <= Level.INFO.intLevel()) {
-			type = WinNT.EVENTLOG_INFORMATION_TYPE;
-			if (level.intLevel() <= Level.WARN.intLevel()) {
-				type = WinNT.EVENTLOG_WARNING_TYPE;
-				if (level.intLevel() <= Level.ERROR.intLevel()) {
-					type = WinNT.EVENTLOG_ERROR_TYPE;
-				}
+		StandardLevel standardLevel = StandardLevel.getStandardLevel(level.intLevel());
+		switch (standardLevel) {
+			case FATAL:
+			case ERROR: {
+				return WinNT.EVENTLOG_ERROR_TYPE;
+			}
+			case WARN: {
+				return WinNT.EVENTLOG_WARNING_TYPE;
+			}
+			default: {
+				return WinNT.EVENTLOG_INFORMATION_TYPE;
 			}
 		}
-
-		return type;
 	}
 
 	/**
@@ -385,23 +386,27 @@ public class Win32EventLogAppender extends AbstractAppender {
 	 * @return EventLog category.
 	 */
 	private static int getEventLogCategory(Level level) {
-		int category = 1;
-		if (level.intLevel() >= Level.DEBUG.intLevel()) {
-			category = 2;
-			if (level.intLevel() >= Level.INFO.intLevel()) {
-				category = 3;
-				if (level.intLevel() >= Level.WARN.intLevel()) {
-					category = 4;
-					if (level.intLevel() >= Level.ERROR.intLevel()) {
-						category = 5;
-						if (level.intLevel() >= Level.FATAL.intLevel()) {
-							category = 6;
-						}
-					}
-				}
+		StandardLevel standardLevel = StandardLevel.getStandardLevel(level.intLevel());
+		switch (standardLevel) {
+			case FATAL: {
+				return 6;
+			}
+			case ERROR: {
+				return 5;
+			}
+			case WARN: {
+				return 4;
+			}
+			case INFO: {
+				return 3;
+			}
+			case DEBUG: {
+				return 2;
+			}
+			default: {
+				return 1;
 			}
 		}
-		return category;
 	}
 
 }

--- a/log4jna-demo/src/test/java/org/dblock/log4jna/nt/demo/test/NewDemoTest.java
+++ b/log4jna-demo/src/test/java/org/dblock/log4jna/nt/demo/test/NewDemoTest.java
@@ -64,7 +64,7 @@ public class NewDemoTest {
 		this.testStartedTime = System.currentTimeMillis() / 1000;
 		this.classUnderTest.trace();
 		this.testEndedTime = System.currentTimeMillis() / 1000;
-		expectEventNoException(Level.TRACE, EventLogType.Informational);
+		expectEventNoException(Level.TRACE, EventLogType.Informational, 1);
 	}
 
 	/**
@@ -75,7 +75,7 @@ public class NewDemoTest {
 		this.testStartedTime = System.currentTimeMillis() / 1000;
 		this.classUnderTest.debug();
 		this.testEndedTime = System.currentTimeMillis() / 1000;
-		expectEventNoException(Level.DEBUG, EventLogType.Informational);
+		expectEventNoException(Level.DEBUG, EventLogType.Informational, 2);
 	}
 
 	/**
@@ -86,7 +86,7 @@ public class NewDemoTest {
 		this.testStartedTime = System.currentTimeMillis() / 1000;
 		this.classUnderTest.info();
 		this.testEndedTime = System.currentTimeMillis() / 1000;
-		expectEventNoException(Level.INFO, EventLogType.Informational);
+		expectEventNoException(Level.INFO, EventLogType.Informational, 3);
 	}
 
 	/**
@@ -97,7 +97,7 @@ public class NewDemoTest {
 		this.testStartedTime = System.currentTimeMillis() / 1000;
 		this.classUnderTest.warn();
 		this.testEndedTime = System.currentTimeMillis() / 1000;
-		expectEventNoException(Level.WARN, EventLogType.Warning);
+		expectEventNoException(Level.WARN, EventLogType.Warning, 4);
 	}
 
 	/**
@@ -108,7 +108,7 @@ public class NewDemoTest {
 		this.testStartedTime = System.currentTimeMillis() / 1000;
 		this.classUnderTest.error();
 		this.testEndedTime = System.currentTimeMillis() / 1000;
-		expectEventNoException(Level.ERROR, EventLogType.Error);
+		expectEventNoException(Level.ERROR, EventLogType.Error, 5);
 	}
 
 	/**
@@ -119,7 +119,7 @@ public class NewDemoTest {
 		this.testStartedTime = System.currentTimeMillis() / 1000;
 		this.classUnderTest.fatal();
 		this.testEndedTime = System.currentTimeMillis() / 1000;
-		expectEventNoException(Level.FATAL, EventLogType.Error);
+		expectEventNoException(Level.FATAL, EventLogType.Error, 6);
 	}
 
 	/**
@@ -130,7 +130,7 @@ public class NewDemoTest {
 		this.testStartedTime = System.currentTimeMillis() / 1000;
 		this.classUnderTest.warnWithException();
 		this.testEndedTime = System.currentTimeMillis() / 1000;
-		expectEventException(Level.WARN, EventLogType.Warning);
+		expectEventException(Level.WARN, EventLogType.Warning, 4);
 	}
 
 	/**
@@ -141,7 +141,7 @@ public class NewDemoTest {
 		this.testStartedTime = System.currentTimeMillis() / 1000;
 		this.classUnderTest.errorWithException();
 		this.testEndedTime = System.currentTimeMillis() / 1000;
-		expectEventException(Level.ERROR, EventLogType.Error);
+		expectEventException(Level.ERROR, EventLogType.Error, 5);
 	}
 
 	/**
@@ -152,14 +152,15 @@ public class NewDemoTest {
 		this.testStartedTime = System.currentTimeMillis() / 1000;
 		this.classUnderTest.fatalWithException();
 		this.testEndedTime = System.currentTimeMillis() / 1000;
-		expectEventException(Level.FATAL, EventLogType.Error);
+		expectEventException(Level.FATAL, EventLogType.Error, 6);
 	}
 
 	/**
 	 * @param level
 	 * @param eventLogType
+	 * @param eventLogCategory
 	 */
-	private void expectEventNoException(Level level, EventLogType eventLogType) {
+	private void expectEventNoException(Level level, EventLogType eventLogType, int eventLogCategory) {
 		EventLogIterator iter = new EventLogIterator(null, EVENT_SOURCE, WinNT.EVENTLOG_BACKWARDS_READ);
 		try {
 			assertTrue("No event log records to process", iter.hasNext());
@@ -175,6 +176,7 @@ public class NewDemoTest {
 					assertEquals(EVENT_SOURCE, record.getSource());
 
 					assertEquals(eventLogType, record.getType());
+					assertEquals(eventLogCategory, record.getRecord().EventCategory.intValue());
 					assertEquals(1, record.getRecord().NumStrings.intValue());
 					assertNull(record.getData());
 
@@ -217,8 +219,9 @@ public class NewDemoTest {
 	/**
 	 * @param level
 	 * @param eventLogType
+	 * @param eventLogCategory
 	 */
-	private void expectEventException(Level level, EventLogType eventLogType) {
+	private void expectEventException(Level level, EventLogType eventLogType, int eventLogCategory) {
 		EventLogIterator iter = new EventLogIterator(null, EVENT_SOURCE, WinNT.EVENTLOG_BACKWARDS_READ);
 		try {
 			assertTrue(iter.hasNext());
@@ -230,6 +233,7 @@ public class NewDemoTest {
 				assertEquals(EVENT_SOURCE, record.getSource());
 
 				assertEquals(eventLogType, record.getType());
+				assertEquals(eventLogCategory, record.getRecord().EventCategory.intValue());
 				assertEquals(1, record.getRecord().NumStrings.intValue());
 				assertNull(record.getData());
 


### PR DESCRIPTION
ref: https://github.com/dblock/log4jna/issues/42

----

@MacTrophy says:

> There seem to have been some changes somewhere in the last 2 years preventing the levels from being properly mapped for the Category label in the EventViewer. In fact they seem reversed, may be Log4j2's levels where changed? I am not fully understanding why I am facing this problem.

I only committed his code from #42

| Log4j2 Level | MessageId (Before) | MessageId (After) |
|--------------|-------------------------------|------------------------------|
| FATAL        | 1                         | 6                        |
| ERROR        | 2                         | 5                        |
| WARN         | 3                         | 4                         |
| INFO         | 4                         | 3                         |
| DEBUG        | 5                         | 2                         |
| TRACE        | 6                         | 1                         |

| MessageId | EventViewer Category |
|:---------:|:--------------------:|
| 1         | Trace                |
| 2         | Debug                |
| 3         | Info                 |
| 4         | Warn                 |
| 5         | Error                |
| 6         | Fatal                |

https://github.com/dblock/log4jna/blob/master/log4jna-win32dll/src/EventLogCategories.mc