### PR TITLE
Bump actions/checkout from 2 to 3

### DIFF
--- a/.github/workflows/Default.yml
+++ b/.github/workflows/Default.yml
@@ -26,7 +26,7 @@ jobs:
     name: Java ${{ matrix.entry.java }} ( ${{ matrix.entry.distribution }} )
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Configuring Developer Command Prompt for Microsoft Visual C++
       - uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -18,7 +18,7 @@ jobs:
     name: Java ${{ matrix.entry.java }} ( ${{ matrix.entry.distribution }} )
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Configuring Developer Command Prompt for Microsoft Visual C++
       - uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -15,7 +15,7 @@ jobs:
     name: Java ${{ matrix.entry.java }} ( ${{ matrix.entry.distribution }} )
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Configuring Developer Command Prompt for Microsoft Visual C++
       - uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/Site.yml
+++ b/.github/workflows/Site.yml
@@ -15,7 +15,7 @@ jobs:
     name: Java ${{ matrix.entry.java }} ( ${{ matrix.entry.distribution }} )
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Configuring Developer Command Prompt for Microsoft Visual C++
       - uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
GitHub Actions Annotations says:
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

So we need to bump actions/checkout from 2 to 3 updated to the node16 runtime by default.
