### PR TITLE
Revert "Update dependency org.sonatype.central:central-publishing-maven-plugin to v0.2.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.2.0</version>
+            <version>0.1.2</version>
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>
@@ -326,7 +326,7 @@
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.2.0</version>
+            <version>0.1.2</version>
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
Reverts dblock/log4jna#239

---

Recent [Log4JNA Deploy](https://github.com/dblock/log4jna/actions/runs/7638106761) was failed. [Maven Central Document says to use v0.1.2](https://central.sonatype.org/publish/publish-portal-maven/) still.